### PR TITLE
(Chore): Optimize filterNotNullKeys

### DIFF
--- a/core/src/main/java/com/kevinmost/koolbelt/extension/MapUtil.kt
+++ b/core/src/main/java/com/kevinmost/koolbelt/extension/MapUtil.kt
@@ -2,7 +2,9 @@ package com.kevinmost.koolbelt.extension
 
 fun <K, V : Any?> Map<K?, V>.filterNotNullKeys(): Map<K, V> {
   @Suppress("UNCHECKED_CAST")
-  return (this.filterKeys { it != null }) as Map<K, V>
+  return this.toMutableMap().also {
+      it.remove(null)
+  } as Map<K, V>
 }
 
 fun <K : Any?, V> Map<K, V?>.filterNotNullValues(): Map<K, V> {


### PR DESCRIPTION
# Context
Currently, `filterNotNulKeys` in `MapUtil` iterates over every single key and removes them if they are null. Since it's a key _set_, we don't actually need to iterate over every single key.

# Technical
We can simply convert the `Map` to a `MutableMap`, remove the `null` key, and recast back into `Map`. This takes us from `O(n)` to `O(1)`.

# TODO
 - [ ] CR
 - [ ] QA